### PR TITLE
Fix for broken music volume with Apple Remote

### DIFF
--- a/plex/Resources/system/keymaps/joystick.AppleRemote.xml
+++ b/plex/Resources/system/keymaps/joystick.AppleRemote.xml
@@ -319,6 +319,8 @@
   </NumericInput>
   <NowPlaying>
     <joystick name="AppleRemote">
+      <button id="1">VolumeUp</button>
+      <button id="2">VolumeDown</button>
       <button id="8">Stop</button>
     </joystick>
   </NowPlaying>


### PR DESCRIPTION
This re-enables the volume control function for music with the Apple remote, a feature broken by Plex in 2014.  Credit to Plex user Diegus83 - https://forums.plex.tv/discussion/comment/671388/#Comment_671388
