### PR TITLE
Simplifies building and packaging on Fedora Linux

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,0 +1,8 @@
+VERSION=1.6.2
+
+rpm-prep:
+	mkdir -p ${HOME}/rpmbuild/SOURCES/
+	tar --transform="s/\./openpht-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/openpht-${VERSION}.tar.gz --exclude=./build --exclude=.git --exclude=*.bz ./ --gzip
+
+rpm: rpm-prep
+	rpmbuild -ba dist/openpht.spec

--- a/dist/openpht
+++ b/dist/openpht
@@ -1,0 +1,4 @@
+#!/bin/sh
+export LD_LIBRARY_PATH=/usr/lib/openpht/system/players/dvdplayer:$LD_LIBRARY_PATH
+export XBMC_HOME=/usr/share/openpht
+exec /usr/lib/openpht/plexhometheater "$@"

--- a/dist/openpht.desktop
+++ b/dist/openpht.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=OpenPHT
+GenericName=OpenPHT
+Comment=OpenPHT is a community driven fork of Plex Home Theater.
+Exec=/usr/bin/openpht
+Icon=openpht
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=AudioVideo;Audio;Video;Player;

--- a/dist/openpht.spec
+++ b/dist/openpht.spec
@@ -1,5 +1,6 @@
 %global _enable_debug_package 0
 %global debug_package %{nil}
+Autoreq: 0
 
 Summary:            OpenPHT is a community driven fork of Plex Home Theater
 Name:               openpht
@@ -28,7 +29,6 @@ BuildRequires:      openssl-devel
 BuildRequires:      glew-devel
 BuildRequires:      avahi-devel
 BuildRequires:      flac-devel
-BuildRequires:      ffmpeg-devel
 BuildRequires:      python-devel
 BuildRequires:      libtiff-devel
 BuildRequires:      libvorbis-devel
@@ -63,7 +63,6 @@ Requires:      openssl
 Requires:      glew
 Requires:      avahi
 Requires:      flac
-Requires:      ffmpeg
 Requires:      python
 Requires:      libtiff
 Requires:      libvorbis
@@ -109,9 +108,13 @@ make -j2
 %install
 cd build
 make install
+cp ../dist/openpht %{buildroot}/usr/bin/openpht
+chmod 755 %{buildroot}/usr/bin/openpht
+cp ../dist/openpht.desktop %{buildroot}/usr/share/applications/openpht.desktop
+chmod 644 %{buildroot}/usr/share/applications/openpht.desktop
 
 %files
 %doc CONTRIBUTORS LICENSE.GPL README
 %{_bindir}/*
-%{_libdir}/*
+%{_prefix}/lib/*
 %{_datadir}/*

--- a/dist/openpht.spec
+++ b/dist/openpht.spec
@@ -1,0 +1,117 @@
+%global _enable_debug_package 0
+%global debug_package %{nil}
+
+Summary:            OpenPHT is a community driven fork of Plex Home Theater
+Name:               openpht
+Version:            1.6.2
+Release:            1%{?dist}
+License:            GPL-2.0
+Group:              Applications/Multimedia
+Source:             openpht-%{version}.tar.gz
+URL:                https://github.com/RasPlex/OpenPHT
+BuildRequires:      cmake
+BuildRequires:      make
+BuildRequires:      gcc
+BuildRequires:      freetype-devel
+BuildRequires:      SDL-devel
+BuildRequires:      SDL_image-devel
+BuildRequires:      libjpeg-turbo-devel
+BuildRequires:      sqlite-devel
+BuildRequires:      curl-devel
+BuildRequires:      lzo-devel
+BuildRequires:      tinyxml-devel
+BuildRequires:      fribidi-devel
+BuildRequires:      fontconfig-devel
+BuildRequires:      yajl-devel
+BuildRequires:      libmicrohttpd-devel
+BuildRequires:      openssl-devel
+BuildRequires:      glew-devel
+BuildRequires:      avahi-devel
+BuildRequires:      flac-devel
+BuildRequires:      ffmpeg-devel
+BuildRequires:      python-devel
+BuildRequires:      libtiff-devel
+BuildRequires:      libvorbis-devel
+BuildRequires:      libmpeg2-devel
+BuildRequires:      libass-devel
+BuildRequires:      librtmp-devel
+BuildRequires:      libplist-devel
+BuildRequires:      shairplay-devel
+BuildRequires:      libva-devel
+BuildRequires:      libvdpau-devel
+BuildRequires:      libcec-devel
+BuildRequires:      swig
+BuildRequires:      boost-devel
+BuildRequires:      libusb-devel
+BuildRequires:      systemd-devel
+BuildRequires:      nasm
+BuildRequires:      libmodplug-devel
+BuildRequires:      libcdio-devel
+Requires:      freetype
+Requires:      SDL
+Requires:      SDL_image
+Requires:      libjpeg-turbo
+Requires:      sqlite
+Requires:      curl
+Requires:      lzo
+Requires:      tinyxml
+Requires:      fribidi
+Requires:      fontconfig
+Requires:      yajl
+Requires:      libmicrohttpd
+Requires:      openssl
+Requires:      glew
+Requires:      avahi
+Requires:      flac
+Requires:      ffmpeg
+Requires:      python
+Requires:      libtiff
+Requires:      libvorbis
+Requires:      libmpeg2
+Requires:      libass
+Requires:      librtmp
+Requires:      libplist
+Requires:      shairplay
+Requires:      libva
+Requires:      libvdpau
+Requires:      libcec
+Requires:      boost
+Requires:      libusb
+Requires:      systemd
+Requires:      libmodplug
+Requires:      libcdio
+
+
+%description
+OpenPHT is a community driven fork of Plex Home Theater. It is used as a client
+for the Plex Media Server.
+
+
+%prep
+%autosetup -n openpht-%{version}
+
+%build
+mkdir build && cd build
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    -DCMAKE_INSTALL_PREFIX='%{buildroot}/usr' \
+    -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS -O2 -mtune=generic -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include" \
+    -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -O2 -mtune=generic -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include" \
+    -DCREATE_BUNDLE='TRUE' \
+    -DDUMP_SYMBOLS='FALSE' \
+    -DENABLE_AUTOUPDATE='FALSE' \
+    -DENABLE_PYTHON='TRUE' \
+    -DPYTHON_EXEC='/usr/bin/python2' \
+    -DUSE_INTERNAL_FFMPEG='TRUE' \
+    -DCMAKE_VERBOSE_MAKEFILE='FALSE'
+make -j2
+
+%install
+cd build
+make install
+
+%files
+%doc CONTRIBUTORS LICENSE.GPL README
+%{_bindir}/*
+%{_libdir}/*
+%{_datadir}/*


### PR DESCRIPTION
This patch includes changes to simplify building and packaging OpenPHT for Fedora Linux. The package was built on Fedora 24, the latest stable version of Fedora.
