### PR TITLE
High Sierra apple remote fix.

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/HIDRemote/HIDRemote.m
+++ b/tools/EventClients/Clients/OSXRemote/HIDRemote/HIDRemote.m
@@ -1046,6 +1046,13 @@ static HIDRemote *sHIDRemote = nil;
 				case kHIDUsage_GD_SystemMenuDown:
 					buttonCode = kHIDRemoteButtonCodeDown;
 				break;
+				case kHIDUsage_Csmr_VolumeIncrement:
+ 					buttonCode = kHIDRemoteButtonCodeUp;
+ 				break;
+ 
+ 				case kHIDUsage_Csmr_VolumeDecrement:
+ 					buttonCode = kHIDRemoteButtonCodeDown;
+ 				break;
 			}
 		break;
 		


### PR DESCRIPTION
This is a quick hit to restore the functionality of Apple Remote up/down buttons which was broken by macOS High Sierra. 

It's identical to the corresponding fix in Kodi (https://github.com/xbmc/xbmc/commit/1c85ba7f44ba9ffe070a732458c105c8025d7157#diff-a3653327954a5d04a64240f50103ec0d).
